### PR TITLE
Fix code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^4.13.0",
     "mongoose": "^6.9.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "express-rate-limit": "^7.4.1"
   }
 }

--- a/backend/routes/images.js
+++ b/backend/routes/images.js
@@ -1,9 +1,16 @@
 const router = require('express').Router();
+const rateLimit = require('express-rate-limit');
 const multer = require('multer');
 const { v4: uuidv4 } = require('uuid');
 
 let path = require('path');
 let Image = require('../models/images.models');
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
 
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
@@ -50,7 +57,7 @@ router.route('/add').post(upload.array('src'), (req, res) => {
 });
 
 
-router.get('/images/:filename', (req, res) => {
+router.get('/images/:filename', limiter, (req, res) => {
   const filename = req.params.filename;
   const filepath = path.join(__dirname, '../images', filename);
   res.sendFile(filepath);


### PR DESCRIPTION
Fixes [https://github.com/Skateallday/alison-abroad/security/code-scanning/7](https://github.com/Skateallday/alison-abroad/security/code-scanning/7)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make to the server within a specified time window.

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the `backend/routes/images.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the specific route handler that performs file system access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
