### PR TITLE
Potential fix for code scanning alert no. 11: Database query built from user-controlled sources

### DIFF
--- a/backend/routes/images.js
+++ b/backend/routes/images.js
@@ -69,8 +69,12 @@ router.put('/:id', async (req, res) => {
   try {
     const id = req.params.id.trim(); // Get the image ID from the request parameters
 
-    // Use the `Image` model to update the image with the specified ID using the data from the request body
-    const updatedImage = await Image.findByIdAndUpdate(id, req.body, { new: true });
+    // Extract the fields to be updated from the request body
+    const { width, height, country, subregion, caption } = req.body;
+    const updateData = { $set: { width, height, country, subregion, caption } };
+
+    // Use the `Image` model to update the image with the specified ID using the sanitized data
+    const updatedImage = await Image.findByIdAndUpdate(id, updateData, { new: true });
 
     if (!updatedImage) {
       return res.status(404).json({ message: 'Image not found' });


### PR DESCRIPTION
Potential fix for [https://github.com/Skateallday/alison-abroad/security/code-scanning/11](https://github.com/Skateallday/alison-abroad/security/code-scanning/11)

To fix the problem, we need to ensure that the data in `req.body` is sanitized before using it in the `Image.findByIdAndUpdate` method. One way to achieve this is by using the `$set` operator to explicitly define which fields can be updated. This ensures that only the intended fields are updated and prevents any malicious data from affecting the query.

We will:
1. Extract the fields from `req.body` that are allowed to be updated.
2. Use the `$set` operator to update only those fields.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
