### PR TITLE
Modify Dependabot settings for updates and groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,42 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
+
 updates:
-  - package-ecosystem: "npm" # Change to match your package manager (e.g., "composer", "pip", "maven")
-    directory: "/" # Adjust if dependencies are in a subfolder
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "some-package" # If you want to ignore specific packages
+      interval: "weekly"
+      day: "monday"
+
+    open-pull-requests-limit: 5
+
     commit-message:
-      prefix: "chore(deps):"
+      prefix: "chore(deps)"
+
     labels:
       - "dependencies"
+
     assignees:
       - "Skateallday"
+
     reviewers:
       - "Skateallday"
+
     rebase-strategy: "auto"
     versioning-strategy: "increase"
 
+    groups:
+      production-deps:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+
+      dev-deps:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+      majors:
+        update-types:
+          - "major"


### PR DESCRIPTION
Updated Dependabot configuration to change the update schedule to weekly and adjusted limits for open pull requests. Added groups for production and development dependencies.